### PR TITLE
Settings Tab Notifier Page>Edit

### DIFF
--- a/wolf/app/views/page/edit.php
+++ b/wolf/app/views/page/edit.php
@@ -44,6 +44,7 @@ if ($action == 'edit') { ?>
             <li class="tab"><a href="#pagetitle"><?php echo __('Page Title'); ?></a></li>
             <li class="tab"><a href="#metadata"><?php echo __('Metadata'); ?></a></li>
             <li class="tab"><a href="#settings"><?php echo __('Settings'); ?></a></li>
+			<?php Observer::notify('view_page_edit_tab_links', $page); ?>
         </ul>
     </div>
     <div id="metainfo-content" class="pages">


### PR DESCRIPTION
I added an Observer event notifier in the Page Edit view that would allow the addition of an HTML li item.  This would allow plugin developers to add their own tab in the settings area.  It would be a much cleaner addition than adding 5 or 6 drop down menus at the bottom of the page.

For your consideration.  Perhaps there's a reason why it wasn't in there already.
