### PR TITLE
fix a few css issues with sitemap pages with children

### DIFF
--- a/wolf/app/views/page/children.php
+++ b/wolf/app/views/page/children.php
@@ -22,7 +22,7 @@
       <span>
       <div class="page">
         <span class="w1">
-          <?php if ($child->has_children): ?><img align="middle" alt="toggle children" class="expander" src="<?php echo URI_PUBLIC;?>wolf/admin/images/<?php echo $child->is_expanded ? 'collapse': 'expand'; ?>.png" title="" /><?php endif; ?>
+          <?php if ($child->has_children): ?><img align="middle" alt="toggle children" class="expander<?php if($child->is_expanded) echo ' expanded'; ?>" src="<?php echo URI_PUBLIC;?>wolf/admin/images/<?php echo $child->is_expanded ? 'collapse': 'expand'; ?>.png" title="" /><?php endif; ?>
 <?php if (!AuthUser::hasPermission('page_edit') || (!AuthUser::hasPermission('admin_edit') && $child->is_protected)): ?>
 <img align="middle" class="icon" src="<?php echo URI_PUBLIC;?>wolf/admin/images/page.png" alt="page icon" /> <span class="title protected"><?php echo $child->title; ?></span> <img class="handle_reorder" src="<?php echo URI_PUBLIC;?>wolf/admin/images/drag_to_sort.gif" alt="<?php echo __('Drag and Drop'); ?>" align="middle" />
 <?php else: ?>

--- a/wolf/app/views/page/index.php
+++ b/wolf/app/views/page/index.php
@@ -131,13 +131,15 @@
                     var parent = $(this).parents("li.node:first")
                     var parentId = parent.attr('id').split('_')[1];
 
-                    $('#page_'+parentId).children('ul').hide();
+                    $('#page_'+parentId).removeClass('children-visible').addClass('children-hidden').children('ul').hide();
                 }
                 else {
                     $(this).addClass("expanded");
                     $(this).attr('src', '<?php echo URI_PUBLIC; ?>wolf/admin/images/collapse.png');
                     var parent = $(this).parents("li.node:first");
                     var parentId = parent.attr('id').split('_')[1];
+                    $('#page_'+parentId).removeClass('children-hidden').addClass('children-visible');
+
                     if ($('#page_'+parentId).children('ul').length == 0) {
                         $('#busy-'+parentId).show();
                         $.get("<?php echo get_url('page/children/'); ?>"+parentId+'/'+'1', function(data) {                        


### PR DESCRIPTION
Due to Fortron's topic on wolf's forum http://www.wolfcms.org/forum/topic1349.html I noticed some css classes weren´t applied when expander icon was clicked.
