### PR TITLE
Changed :any and added :all to Dispatcher

### DIFF
--- a/wolf/Framework.php
+++ b/wolf/Framework.php
@@ -132,7 +132,7 @@ final class Dispatcher {
         foreach (self::$routes as $route => $uri) {
             // Convert wildcards to regex
             if (strpos($route, ':') !== false) {
-                $route = str_replace(':any', '(.+)', str_replace(':num', '([0-9]+)', $route));
+                $route = str_replace(':any', '([^/]+)', str_replace(':num', '([0-9]+)', str_replace(':all', '(.+)', $route)));
             }
 
             // Does the regex match?


### PR DESCRIPTION
- Changed :any to disallow slashes ([^/]+)
- Added :all which is a clone of the old :any and allows everything (.+)

The old :any caused confusing and cumbersome plugin routes where multiple URLs would redirect to the same page. If you had a route like this:

'/page/:any' => '/plugin/function/page'

Inappropriate URLs like '/page/example/example' would be redirected to your page when it should have gone to a 404.
