### PR TITLE
Adding preventDefault on dynamic uninstall function.

### DIFF
--- a/wolf/app/views/setting/index.php
+++ b/wolf/app/views/setting/index.php
@@ -229,13 +229,14 @@ $(document).ready(function() {
     });
 
     // Dynamically uninstall
-    $('.uninstall a').click(function() {
+    $('.uninstall a').click(function(e) {
         if (confirm('<?php echo __('Are you sure you wish to uninstall this plugin?'); ?>')) {
             var pluginId = this.name.replace('uninstall_', '');
             $.get('<?php echo get_url('setting/uninstall_plugin/'); ?>'+pluginId, function() {
                 location.reload(true);
             });
         }
+        e.preventDefault();
     });
 
 });


### PR DESCRIPTION
Currently if you click ok or cancel the url still refreshes, I found this being trouble for me trying to debug a plugin. I then realised that the link has a url specified and there is nothing in the javascript to stop that url from running. This should fix that issue and make sure that the ajax get function runs first before page reloads.
