### PR TITLE
Changing the elements order in <title></title> tags. The reason I propose this ...

### DIFF
--- a/wolf/app/layouts/backend.php
+++ b/wolf/app/layouts/backend.php
@@ -41,7 +41,7 @@ if (isset($this->vars['content_for_layout']->vars['action'])) {
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-    <title><?php use_helper('Kses'); echo kses(Setting::get('admin_title'), array()) . ' - ' . $title; ?></title>
+    
     <title><?php use_helper('Kses'); echo $title . ' - ' . kses(Setting::get('admin_title'), array()); ?></title>
 
     <link rel="favourites icon" href="<?php echo URI_PUBLIC; ?>wolf/admin/images/favicon.ico" />


### PR DESCRIPTION
...is the fact that when you develop site in browser with multiple tabs, the MORE important thing to see in a tab is obviously the **_$title**_ than **_Setting::get('admin_title')**_. 

Eg. "Pages - Edit - Contact page - THE_WEBSITE_TITLE" instead of "THE_WEBSITE_TITLE - Pages - Edit - Contact".

This way, when you can more easily see what each tab contains, as most important part of title isn't truncated by the width of browser's tab. 

This is just an _usability / user performance_ issue but I personally would love to see it merged in future releases of Wolf.
