### PR TITLE
Fix for issue #337

### DIFF
--- a/wolf/app/controllers/PageController.php
+++ b/wolf/app/controllers/PageController.php
@@ -280,8 +280,6 @@ class PageController extends Controller {
 
         $page = Record::findByIdFrom('Page', $new_root_id);
         $page->position += 1;
-        $page->created_on_time = time();
-        $page->published_on_time = $page->created_on_time;
         $page->save();
 
         $newUrl = URL_PUBLIC;


### PR DESCRIPTION
The bug in question where the time value for the cloned page adds a
bunch of numbers to the end (actually the UNIX time) is actually not
SQLite specific.

Due to the way the Page model handles "created_on_time", it appended
the unix time to the end of "created_on". This variable looks to be a
remnant from an earlier one related to the fork from FrogCMS(?).

It only manifested itself in SQLite because SQLite does not enforce
column types strictly, whereas in MySQL the extra numbers are discarded
by the DB, SQLite stores them as a string.

Removing the offending lines fixes the issue and does not change the
functionality of clone().
