### PR TITLE
Fix issues #305, #324, #355 related to SQLite implementation

### DIFF
--- a/wolf/Framework.php
+++ b/wolf/Framework.php
@@ -595,6 +595,10 @@ class Record {
                     if (self::$__CONN__->getAttribute(PDO::ATTR_DRIVER_NAME) != 'sqlite') {
                         $value_of[$column] = $column.'=DEFAULT';
                     }
+					else{
+						//Since DEFAULT values don't work in SQLite empty strings should be passed explicitly
+						$value_of[$column] = $column."=''";
+					}
                 }
             }
 


### PR DESCRIPTION
The three bugs (and others duplicated such as #356) were all related to one single problem in the `Framework`, namely that empty values were not being handled properly for SQLite. Since SQLite does not properly support the `DEFAULT` keyword the same way MySQL and PostgreSQL do, an empty string must be explicitly passed in order to properly update the record. The issues mentioned all involved attempting to insert empty values in the database which was not caught by the `if` statement on line 590.
