### PR TITLE
Fix issue #426 for delete button on newly cloned page

### DIFF
--- a/wolf/app/controllers/PageController.php
+++ b/wolf/app/controllers/PageController.php
@@ -295,7 +295,7 @@ class PageController extends Controller {
             $page->slug(),
             $newUrl,
             get_url('page/add', $new_root_id),
-            get_url('page/delete/'.$new_root_id));
+            get_url('page/delete/'.$new_root_id.'?csrf_token='.SecureToken::generateToken(BASE_URL.'page/delete/'.$new_root_id)));
         echo implode('||', $newData);
     }
 

--- a/wolf/app/views/page/index.php
+++ b/wolf/app/views/page/index.php
@@ -277,6 +277,8 @@
 						newobj.find('.view-link').attr('href', data[4]); // set the view page link
 						newobj.find('.add-child-link').attr('href', data[5]); // set the add child link
 						newobj.find('.remove').attr('href', data[6]); // set the delete link
+						newobj.find('.remove').attr('onclick', '').unbind('click'); //remove old confirm dialog for delete link (needs both for IE/FF/Chrome)
+						newobj.find('.remove').click(function(){return confirm('Are you sure you want to delete '+data[2]+' and its underlying pages?');}); //set the onclick dialog box for delete link
 						newobj.find('.copy-page').attr('id', 'copy-'+newid); // set the copy id						
 						
 						$("#page_"+id[1]).after(newobj); // add row to dom and slide down


### PR DESCRIPTION
The delete button on a newly cloned page was not fully updated and did
not generate a CSRF token so did not allow delete. Also updated the
onclick message to reflect the new name after a copy.
