### PR TITLE
Fix for issue #440

### DIFF
--- a/wolf/app/models/Snippet.php
+++ b/wolf/app/models/Snippet.php
@@ -48,7 +48,12 @@ class Snippet extends Record {
     }
 
     public function beforeSave() {
-    // apply filter to save is generated result in the database
+        // snippet name should not be empty
+        if (empty($this->name)) {
+            return false;
+        }
+        
+        // apply filter to save is generated result in the database
         if ( ! empty($this->filter_id)) {
             $this->content_html = Filter::get($this->filter_id)->apply($this->content);
         }


### PR DESCRIPTION
Checks if snippet name is not empty in beforeSave(), preventing snippets without a name.
