### PR TITLE
Smart Flash infoboxes (delay based on length) 

### DIFF
--- a/wolf/app/layouts/backend.php
+++ b/wolf/app/layouts/backend.php
@@ -83,7 +83,7 @@ if (!isset($title) || trim($title) == '') {
         $(document).ready(function() {
             (function showMessages(e) {
                 e.fadeIn('slow')
-                 .animate({opacity: 1.0}, 1500)
+                 .animate({opacity: 1.0}, Math.min(5000, parseInt(e.text().length * 50)))
                  .fadeOut('slow', function() {
                     if ($(this).next().attr('class') == 'message') {
                         showMessages($(this).next());


### PR DESCRIPTION
Some longer messages disappeared too quickly (1500ms) IMO.

This makes Flash::set('success|error|info') messages appear 
for time period based on message length.

Each letter in message's text adds 50 milliseconds to display time,
so short messages disappear quickly while long ones are visible longer.

Maximum proposed display time is 5000 ms.
