### PR TITLE
Fixes a bug where saving an extisting page causes a duplicate slug error

### DIFF
--- a/wolf/app/controllers/PageController.php
+++ b/wolf/app/controllers/PageController.php
@@ -396,7 +396,7 @@ class PageController extends Controller {
             if (!Validate::slug($data['slug']) && (!empty($data['slug']) && $id == '1')) {
                 $errors[] = __('Illegal value for :fieldname field!', array(':fieldname' => 'slug'));
             }
-            if (Record::existsIn('Page','parent_id = :parent_id AND slug = :slug',array(':parent_id' => $data['parent_id'], ':slug' => $data['slug']))) {
+            if (Record::existsIn('Page','parent_id = :parent_id AND slug = :slug AND id <> :id',array(':parent_id' => $data['parent_id'], ':slug' => $data['slug'], ':id' => $id))) {
                 $errors[] = __('Page with slug <b>:slug</b> already exists!', array(':slug' => $data['slug']));
             }            
         }


### PR DESCRIPTION
As described in issue #468, @marekmurawski's patch causes a small bug that doesn't let you save an updated page. This patch should fix it.
