### PR TITLE
lastInsertId support for PostgreSQL

### DIFF
--- a/wolf/Framework.php
+++ b/wolf/Framework.php
@@ -514,6 +514,13 @@ class Record {
      * @return string A key.
      */
     final public static function lastInsertId() {
+        // PostgreSQL does not support lastInsertId retrieval without knowing the sequence name
+        if (self::$__CONN__->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
+            $sql = 'SELECT lastval();';
+            
+            return self::$__CONN__->query($sql)->fetchColumn();
+        }
+        
         return self::$__CONN__->lastInsertId();
     }
 


### PR DESCRIPTION
PostgreSQL does not support lastInsertId retrieval without knowing the sequence name. I've added a work-around.
