### PR TITLE
Fixes problems with parent() function

### DIFF
--- a/wolf/app/models/Page.php
+++ b/wolf/app/models/Page.php
@@ -311,12 +311,12 @@ class Page extends Node {
         if ($level === null)
             return $this->parent;
 
-        if ($level > $this->level)
+        if ($level > $this->level())
             return false;
-        else if ($this->level == $level)
+        else if ($this->level() == $level)
             return $this;
         else
-            return $this->parent($level);
+            return $this->parent->parent($level);
     }
 
 


### PR DESCRIPTION
Fixes issue #420.

My explanation, from the forum:

It looks like the problem is that the parent() function uses $this->level to determine the level of the current page. When $this->level is not set, it will be evaluated as 0, causing the function to believe that every page is the Home page. Therefore parent(0) will return the current page and all higher values will return FALSE.

Therefore in wolf/app/models/Page.php, in function parent() all references to $this->level should be replaced by $this->level().

Furthermore,

``` php
return $this->parent($level);
```

should be:

``` php
return $this->parent->parent($level);
```

Otherwise the function will keep repeating itself endlessly.

(http://www.wolfcms.org/forum/post13522.html#p13522)
