### PR TITLE
Translates (deprecated) POSIX functions to PCRE, fixing #441

### DIFF
--- a/wolf/helpers/Upload.php
+++ b/wolf/helpers/Upload.php
@@ -348,7 +348,7 @@ class Upload {
      * @return  void
      */
     function setMaxFilesize($n) {
-        $this->max_size = ( ! eregi("^[[:digit:]]+$", $n)) ? 0 : $n;
+        $this->max_size = ( ! preg_match('#^\d+$#i', $n)) ? 0 : (int) $n;
     }
 
     // --------------------------------------------------------------------
@@ -361,7 +361,7 @@ class Upload {
      * @return  void
      */
     function setMaxWidth($n) {
-        $this->max_width = ( ! eregi("^[[:digit:]]+$", $n)) ? 0 : $n;
+        $this->max_width = ( ! preg_match('#^\d+$#i', $n)) ? 0 : (int) $n;
     }
 
     // --------------------------------------------------------------------
@@ -374,7 +374,7 @@ class Upload {
      * @return  void
      */
     function setMaxHeight($n) {
-        $this->max_height = ( ! eregi("^[[:digit:]]+$", $n)) ? 0 : $n;
+        $this->max_height = ( ! preg_match('#^\d+$#i', $n)) ? 0 : (int) $n;
     }
 
     // --------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue #441.

> **eregi()** was deprecated at PHP 5.3 in favor of the PCRE extension. The use of **eregi()** can cause warnings in some scenarios. 

This patch translates the old eregi() functions to preg_match() (including the **i** / **PCRE_CASELESS** modifier).

It also casts the result to integer to be absolutely 100% sure the value is saved as an integer.
