### PR TITLE
Validate::slug() dot (period) character support

### DIFF
--- a/wolf/helpers/Validate.php
+++ b/wolf/helpers/Validate.php
@@ -459,11 +459,13 @@ class Validate {
 
     /**
      * Checks wheter a string is a valid slug.
+     * 
+     * Valid slugs can only contain [a-z] lowercase letters, "-", "_", "." and digits.
      *
      * @param string $str Slug
      */
     public static function slug($str, $utf8 = FALSE) {
-        return ($utf8 === TRUE) ? (bool) preg_match('/^[-\pLl\pN_]++$/uD', (string) $str) : (bool) preg_match('/^[-a-z0-9_]++$/D', (string) $str);
+        return ($utf8 === TRUE) ? (bool) preg_match('/^[-\pLl\pN_.]++$/uD', (string) $str) : (bool) preg_match('/^[-a-z0-9_.]++$/D', (string) $str);
     }
 
 


### PR DESCRIPTION
As discussed in #478

Added dot/period character to be allowed in slug.
