### PR TITLE
Observer::notify('user_after_XXX') change

### DIFF
--- a/wolf/app/controllers/UserController.php
+++ b/wolf/app/controllers/UserController.php
@@ -171,7 +171,7 @@ class UserController extends Controller {
                 UserRole::setRolesFor($user->id, $_POST['user_role']);
 
             Flash::set('success', __('User has been added!'));
-            Observer::notify('user_after_add', $user->name);
+            Observer::notify('user_after_add', $user->name, $user->id);
         }
         else {
             Flash::set('error', __('User has not been added!'));
@@ -295,7 +295,7 @@ class UserController extends Controller {
             }
 
             Flash::set('success', __('User has been saved!'));
-            Observer::notify('user_after_edit', $user->name);
+            Observer::notify('user_after_edit', $user->name, $user->id);
         }
         else {
             Flash::set('error', __('User has not been saved!'));
@@ -344,7 +344,7 @@ class UserController extends Controller {
                     // delete user-roles relationship
                     UserRole::setRolesFor($user->id, array());
                     Flash::set('success', __('User <strong>:name</strong> has been deleted!', array(':name' => $user->name)));
-                    Observer::notify('user_after_delete', $user->name);
+                    Observer::notify('user_after_delete', $user->name, $user->id);
                 }
                 else {
                     Flash::set('error', __('User <strong>:name</strong> has not been deleted!', array(':name' => $user->name)));


### PR DESCRIPTION
All three notifiers **shouldn't** use `$user->name` as passed variable, since `$user->name` cannot **uniquely** identify user. (`$user->username` does )

More meaningful variable passed to observer will be `$user->id` - which 
can uniquely identify user's record in DB.

**Added** second parameter `$user->id` and _leaved_ `$user->name` for backwards compatibility.
