### PR TITLE
Slug validation/csrf error in edit page

### DIFF
--- a/wolf/app/controllers/PageController.php
+++ b/wolf/app/controllers/PageController.php
@@ -393,7 +393,8 @@ class PageController extends Controller {
             if ($data['slug'] == ADMIN_DIR) {
                 $errors[] = __('You cannot have a slug named :slug!', array(':slug' => ADMIN_DIR));
             }
-            if ( (!Validate::slug($data['slug']) && ($id != '1') ) || (!empty($data['slug']) && ($id == '1')) ) {
+            // Make sure home's slug is passed ok, but other slugs are validated properly
+            if (($id != '1' && (!Validate::slug($data['slug']) || empty($data['slug']))) || ($id == '1' && !empty($data['slug']))) {
                 $errors[] = __('Illegal value for :fieldname field!', array(':fieldname' => 'slug'));
             }
             if (Record::existsIn('Page','parent_id = :parent_id AND slug = :slug AND id <> :id',array(':parent_id' => $data['parent_id'], ':slug' => $data['slug'], ':id' => $id))) {


### PR DESCRIPTION
Martijn, please include this in 0.7.6 re-release :smile:
### Slug validation

Slug validation bug - slug wasn't actually checked due to if statement parentheses/logic error. This way user could enter page slug with forbidden chars like "/#&" etc.

Now slug is properly checked against Validate::slug()
### CSRF upon errors

If user entered invalid value which generated Flash error, the CSRF token used for regenerated View was set with invalid path so user additionally got "Invalid CSRF token found" message.

This forced user to load clean (non-POST) version of page and start all edits again.

Fixed CSRF for View to reflect the same path as POSTing page (page/edit/# or page/add)
