### PR TITLE
installation frontend javascript bugfix - win/xampp

### DIFF
--- a/wolf/install/install.php
+++ b/wolf/install/install.php
@@ -25,9 +25,9 @@ $drivers = PDO::getAvailableDrivers();
     // <![CDATA[
         $(document).ready(function() {
             $('#config_db_driver').change(function() {
-                
+
                 if (this.value == 'sqlite') {
-                    $('#config_db_name').val('<?php echo realpath(dirname(__FILE__).'/../../../').'/db/wolf.sq3' ?>');
+                    $('#config_db_name').val('<?php echo str_replace('\\','/',realpath(dirname(__FILE__).'/../../../')).'/db/wolf.sq3' ?>');
                     $('#help-db-name').html('Required. Enter the <strong>absolute</strong> path to the database file.<br/>You are <strong>strongly</strong> advised to keep the Wolf CMS SQLite database outside of the webserver root.');
                     $('#help-db-prefix').html('Optional. Usefull to prevent conflicts if you have, or plan to have, multiple Wolf installations with a single database.');
                     $('#row-table-prefix label').addClass('optional');
@@ -63,7 +63,7 @@ $drivers = PDO::getAvailableDrivers();
 
             $('#config_db_driver').trigger('change');
         });
-        
+
     // ]]>
     </script>
 
@@ -82,7 +82,7 @@ $drivers = PDO::getAvailableDrivers();
             <tr>
                 <td class="label"><label for="config_db_driver">Database driver</label></td>
                 <td class="field">
-                    <select id="config_db_driver" name="config[db_driver]" onchange="db_driver_change(this[this.selectedIndex].value);">
+                    <select id="config_db_driver" name="config[db_driver]">
                         <?php /*if (isset($_POST['dbtype']) && !empty($_POST['dbtype']) && $_POST['dbtype'] == 'sqlite') {
                             echo '<option value="sqlite">SQLite 3</option>';
                         }


### PR DESCRIPTION
Windows only issue:

The following issues appear when changing select-box for DB type in installation screen.

Solution: 

Using str_replace to replace **backslashes** to **forward-slashes** in case of SQLite. 
Windows PHP understands forward slashes correctly. 

The reason I submitted this is because of potential javascript error while installation to windows folder name starting with `x` :angry: letter (like in xampp). In essence - trying to set something like this:

``` javascript
$('#config_db_name').val('C:\xampp\db\wolf.sq3')
```

the `\xam` part of the above string is treated as an escaped **octal code** in string and generates browser's **javascript syntax error**.

Converting path string to use forward slashes in PHP resolves this resulting in:

``` javascript
$('#config_db_name').val('C:/xampp/db/wolf.sq3')
```

Additionaly, removed `#config_db_driver` **onchange** property which called non-existing fuction `db_driver_change` - this also generated **browser errors**.

Not essential but this may be very discouraging for people trying to install test SQLite Wolf in Windows ;)
