### PR TITLE
Fixing Record::lastInsertId()

### DIFF
--- a/wolf/Framework.php
+++ b/wolf/Framework.php
@@ -519,7 +519,12 @@ class Record {
         if (self::$__CONN__->getAttribute(PDO::ATTR_DRIVER_NAME) === 'pgsql') {
             $sql = 'SELECT lastval();';
             
-            return self::$__CONN__->query($sql)->fetchColumn();
+            if ($result = self::$__CONN__->query($sql)) {
+                return $result->fetchColumn();
+            }
+            else {
+                return 0;
+            }
         }
         
         return self::$__CONN__->lastInsertId();


### PR DESCRIPTION
As I explained in pull request #473, wrapping fetchColumn() inside an if-statement will avoid a fatal error. At the same time we can return 0, making sure that the method will pass the phpunit tests (and is consistent with PDO's native lastInsertId() function).
