### PR TITLE
Fix auto-loading namespaced classes

### DIFF
--- a/wolf/Framework.php
+++ b/wolf/Framework.php
@@ -1287,7 +1287,7 @@ class AutoLoader {
         } else {
             foreach (self::$folders as $folder) {
                 $folder = rtrim($folder, DIRECTORY_SEPARATOR);
-                $file = $folder.DIRECTORY_SEPARATOR.$class_name.'.php';
+                $file = $folder.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $class_name).'.php';
                 if (file_exists($file)) {
                     require $file;
                     return;


### PR DESCRIPTION
Currently, the autoloader will not properly load namespaced classes if only a folder to look into has been specified.

This kind of kills the idea of having the autoloader in the first place when you have to individually define classes that are in a namespace. Having the autoloader replace the namespace separator with DIRECTORY_SEPARATOR allows the autoloader to look for a proper PSR-0 -like folder structure, instead of just blindly trying `/path/to/the/Namespace\Class.php`.
