### PR TITLE
Avoid duplicate User->username in controller

### DIFF
--- a/wolf/app/controllers/UserController.php
+++ b/wolf/app/controllers/UserController.php
@@ -150,6 +150,11 @@ class UserController extends Controller {
             // @todo Remove hardcoded reset to 'en' language
             $data['language'] = 'en';
         }
+        
+        // Check if user with the same 'username' already exists
+        if ( Record::existsIn('User', 'username=:username', array( ':username' => $data['username'] )) ) {
+            $errors[] = __('Username <b>:username</b> is already in use, please choose other!', array( ':username' => $data['username'] ));
+        }
 
         Flash::set('post_data', (object) $data);
 
@@ -270,7 +275,12 @@ class UserController extends Controller {
         if (!empty($data['language']) && !Validate::alpha_dash($data['language'])) {
             $errors[] = __('Illegal value for :fieldname field!', array(':fieldname' => 'language'));
         }
-
+        
+        // Check if user with the same 'username' already exists
+        if ( Record::existsIn('User', 'username=:username', array( ':username' => $data['username'] )) ) {
+            $errors[] = __('Username <b>:username</b> is already in use, please choose other!', array( ':username' => $data['username'] ));
+        }
+        
         if ($errors !== false) {
             // Set the errors to be displayed.
             Flash::set('error', implode('<br/>', $errors));

--- a/wolf/app/i18n/en-message.php
+++ b/wolf/app/i18n/en-message.php
@@ -175,6 +175,7 @@ return array(
     'User not found!' => 'User not found!',
     'Username' => 'Username',
     'Username must contain a minimum of 3 characters!' => 'Username must contain a minimum of 3 characters!',
+    'Username <b>:username</b> is already in use, please choose other!' => 'Username <b>:username</b> is already in use, please choose other!',
     'Users' => 'Users',
     'Valid until date' => 'Valid until date',
     'Version' => 'Version',


### PR DESCRIPTION
fixes #515

Additional checks in `UserController.php` to prevent addition or editing _(via POST forgery)_ User with same `username` as existing one. Also added I18n string to `en-message.php` only
