### PR TITLE
Hotfix for issue #553

### DIFF
--- a/wolf/app/models/Page.php
+++ b/wolf/app/models/Page.php
@@ -1141,9 +1141,15 @@ class Page extends Node {
     }
 
 
-    public static function childrenOf($id) {
+    /**
+     * Returns all children (including those with a status other than published) of a Page.
+     * 
+     * @param   int     $parent_id  ID of the parent Page
+     * @return  array               Array containing Page objects
+     */
+    public static function childrenOf($parent_id) {
         return self::find(array(
-            'where' => array('parent_id = :parent_id', ':parent_id' => $id),
+            'where' => array('parent_id = :parent_id', ':parent_id' => $parent_id),
             'order' => 'page.position ASC, page.id DESC'
         ));
     }


### PR DESCRIPTION
This is a hotfix for issue #553 (Backend Pages tab doesn't show pages with status != published).

The first commit rewinds commit decc9f3cc8c3f642ff90d00d74dc543a04fbdd5f but at the same time improves the method (by replacing a vulnerable `where` statement with one that includes a named parameter), making it more secure against SQL injection.

In the second commit I added some documentation to the method (to avoid confusion in the future) and renamed the (internal) `$id` parameter into `$parent_id`.
