### PR TITLE
fixes #418 - prevent non-admin from setting "is_protected" of page

### DIFF
--- a/wolf/app/controllers/PageController.php
+++ b/wolf/app/controllers/PageController.php
@@ -450,6 +450,12 @@ class PageController extends Controller {
             $errors[] = __('Illegal value for :fieldname field!', array(':fieldname' => 'behaviour_id'));
         }
 
+        // Check is_protected field
+        if (!empty($data['is_protected']) && !AuthUser::hasPermission('admin_edit')) {
+            $errors[] = __('Only administrators can change <b>protected</b> status of pages!');
+            unset($data['is_protected']);
+        }
+        
         // Make sure the title doesn't contain HTML
         if (Setting::get('allow_html_title') == 'off') {
             use_helper('Kses');

--- a/wolf/app/i18n/en-message.php
+++ b/wolf/app/i18n/en-message.php
@@ -105,6 +105,7 @@ return array(
     'No CSRF token found!' => 'No CSRF token found!',
     'No user found!' => 'No user found!',
     'One or more required PHP extension is missing: :exts' => 'One or more required PHP extension is missing: :exts',
+    'Only administrators can change <b>protected</b> status of pages!' => 'Only administrators can change <b>protected</b> status of pages!',
     'Only for filter in pages, NOT in snippets' => 'Only for filter in pages, NOT in snippets',
     'Optional. Please use a valid e-mail address.' => 'Optional. Please use a valid e-mail address.',
     'Page' => 'Page',

--- a/wolf/app/views/page/edit.php
+++ b/wolf/app/views/page/edit.php
@@ -149,7 +149,7 @@ if ($action == 'edit') { ?>
                         <option value="<?php echo Page::LOGIN_NOT_REQUIRED; ?>"<?php echo $page->needs_login == Page::LOGIN_NOT_REQUIRED ? ' selected="selected"': ''; ?>><?php echo __('not required'); ?></option>
                         <option value="<?php echo Page::LOGIN_REQUIRED; ?>"<?php echo $page->needs_login == Page::LOGIN_REQUIRED ? ' selected="selected"': ''; ?>><?php echo __('required'); ?></option>
                     </select>
-                    <input id="page_is_protected" name="page[is_protected]" class="checkbox" type="checkbox" value="1"<?php if ($page->is_protected) echo ' checked="checked"'; ?>/><label for="page_is_protected" title="<?php echo __('When enabled, only users who are an administrator can edit the page.'); ?>"> <?php echo __('Protected'); ?> </label>
+                      <input id="page_is_protected" name="page[is_protected]" class="checkbox" type="checkbox" value="1"<?php if ($page->is_protected) echo ' checked="checked"'; ?><?php if (!AuthUser::hasPermission('admin_edit')) echo ' disabled="disabled"'; ?>/><label for="page_is_protected" title="<?php echo __('When enabled, only users who are an administrator can edit the page.'); ?>"> <?php echo __('Protected'); ?> </label>
                   </td>
                 </tr>
               <?php endif; ?>


### PR DESCRIPTION
Fixes #418

Prevent non-administrators _(those not having `admin_edit` permission)_ from setting **is_protected** of Page
1. Controller permission_check
2. In Page edit view - non-admins see disabled (greyed-out) checkbox for this setting.
3. Added `en` I18n string for error message.
