### PR TITLE
Fixes #358 - unable to edit '*.html' files in File Manager

### DIFF
--- a/wolf/plugins/file_manager/FileManagerController.php
+++ b/wolf/plugins/file_manager/FileManagerController.php
@@ -134,7 +134,7 @@ class FileManagerController extends PluginController {
         // We don't allow leading slashes
         $filename = preg_replace('/^\//', '', $filename);
         
-        // Check if file had URL_SUFFIX - if so, and append it
+        // Check if file had URL_SUFFIX - if so, append it to filename
         $filename .= ($_GET['has_url_suffix']==='1') ? URL_SUFFIX : '';
         
         $file = FILES_DIR . '/' . $filename;


### PR DESCRIPTION
Problem: Unable to edit files ending with `.html` extension in File Manager

Reason: Wolf at the very beginning of request processing strips URL_SUFFIX from requests.

Proposed workaround: For files ending with URL_SUFFIX - add `has_url_suffix=1` to query string and detect it's presence while viewing/editing those files.

Not very pretty but works for both `USE_MOD_REWRITE=true` and `false`
