### PR TITLE
Don't throw exceptions in AutoLoader::load().

### DIFF
--- a/wolf/Framework.php
+++ b/wolf/Framework.php
@@ -1627,7 +1627,6 @@ class AutoLoader {
                 }
             }
         }
-        throw new Exception("AutoLoader could not find file for '{$class_name}'.");
     }
 
 } // end AutoLoader class


### PR DESCRIPTION
PHP calls each SPL autoloader function on the stack. Each registered
function might or might not load the appropriate module.
The WolfCMS autoloader function unfortunately throws an exception if the
module for a requested class name could not be found, effectively
preventing any other autoloaders on the stack from being run (and
eventually loading the required module).

This is the obvious fix (not throwing). I'm not quite sure about the
side effects this might have for Wolf though.

See the related WolfCMS forum post:
https://www.wolfcms.org/forum/topic3950.html

I also found this discussion on stackoverflow quite helpful:
https://stackoverflow.com/questions/1579080/throwing-exceptions-in-an-spl-autoloader
