### PR TITLE
Fixes deprecated jQuery reference in install.php

### DIFF
--- a/wolf/install/install.php
+++ b/wolf/install/install.php
@@ -20,7 +20,7 @@ if (!defined('INSTALL_SEQUENCE')) {
 $drivers = PDO::getAvailableDrivers();
 ?>
 
-    <script type="text/javascript" charset="utf-8" src="../admin/javascripts/jquery-1.6.2.min.js"></script>
+    <script type="text/javascript" charset="utf-8" src="../admin/javascripts/jquery-1.8.3.min.js"></script>
     <script type="text/javascript">
     // <![CDATA[
         $(document).ready(function() {


### PR DESCRIPTION
Updates the jQuery reference from 1.6.2 to 1.8.3. The previous dead link prevented the db-selector from working (i.e. switching to sqlite3).
