### PR TITLE
fix: expression is always true

### DIFF
--- a/wolf/helpers/Email.php
+++ b/wolf/helpers/Email.php
@@ -421,7 +421,7 @@ class Email {
      * @return  void
      */
     function setNewline($newline = "\n") {
-        if ($newline != "\n" || $newline != "\r\n" || $newline != "\r") {
+        if ($newline != "\n" && $newline != "\r\n" && $newline != "\r") {
             $this->newline = "\n";
             return;
         }


### PR DESCRIPTION
Expression is always true regardless "$newline" value.

This possible defect found by [AppChecker ](http://cnpo.ru/en/solutions/appchecker.php)
@wolfcms/core-developers

