### PR TITLE
Fixed bug #520: childrenCount() and children() not working on PostgreSQL

### DIFF
--- a/wolf/app/models/Page.php
+++ b/wolf/app/models/Page.php
@@ -320,7 +320,7 @@ class Page extends Node {
         // Prepare SQL
         $sql = 'SELECT COUNT(*) AS nb_rows FROM '.TABLE_PREFIX.'page '
                 .'WHERE parent_id = '.$this->id
-                ." AND (COALESCE(valid_until, '') = '' OR '".date('Y-m-d H:i:s')."' < valid_until)"
+                ." AND (valid_until IS NULL OR '".date('Y-m-d H:i:s')."' < valid_until)"
                 .' AND (status_id='.Page::STATUS_PUBLISHED
                 .($include_hidden ? ' OR status_id='.Page::STATUS_HIDDEN : '').') '
                 ."$where_string ORDER BY $order $limit_string $offset_string";
@@ -652,7 +652,7 @@ class Page extends Node {
                 .'LEFT JOIN '.TABLE_PREFIX.'user AS author ON author.id = page.created_by_id '
                 .'LEFT JOIN '.TABLE_PREFIX.'user AS updater ON updater.id = page.updated_by_id '
                 .'WHERE parent_id = '.$this->id.' AND (status_id='.Page::STATUS_PUBLISHED.($include_hidden ? ' OR status_id='.Page::STATUS_HIDDEN : '').') '
-                ." AND (COALESCE(valid_until, '') = '' OR '".date('Y-m-d H:i:s')."' < valid_until)"
+                ." AND (valid_until IS NULL OR '".date('Y-m-d H:i:s')."' < valid_until)"
                 ."$where_string ORDER BY $order $limit_string $offset_string";
 
         self::logQuery($sql);


### PR DESCRIPTION
Fixes #520 

Changes proposed in this pull request:

- Use valid_until IS NULL instead of COALESCE(valid_until, '') = '' to get the PostgreSQL working.

- SQLite checked locally and working.
- MySQL checked locally and working.

@wolfcms/core-developers

